### PR TITLE
[IMP][13.0] fleet_operations: Hide menu update next service day.

### DIFF
--- a/fleet_operations/wizard/update_next_service.py
+++ b/fleet_operations/wizard/update_next_service.py
@@ -4,11 +4,12 @@
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError, Warning
 
+
 class UpdateNextServiceConfig(models.TransientModel):
     """Added Next Service and Odometer Increment."""
 
     _name = 'update.next.service.config'
-    _description = 'Update Next Service congiguration'
+    _description = 'Update Next Service configuration'
 
     vehicle_id = fields.Many2one('fleet.vehicle', string="Vehicle Id")
     number = fields.Float(string="Odometer Increment")
@@ -30,7 +31,6 @@ class UpdateNextServiceConfig(models.TransientModel):
         next_ser_configs = self.env['next.service.days'].search([('vehicle_id','=',self.vehicle_id.id)])
         if not next_ser_configs:
             next_service_obj.create(next_days)
-
 
         next_odometer = {
             'vehicle_id': self.vehicle_id and self.vehicle_id.id or False,

--- a/fleet_operations/wizard/update_next_service.xml
+++ b/fleet_operations/wizard/update_next_service.xml
@@ -31,9 +31,9 @@
         <field name="target">new</field>
    </record>
 
-   <!-- Menuitem for Repair Line Summary. -->
-   <menuitem action="action_update_next_service_day"
-             name="Update Next Service Day"
-             id="next_service_day_menu"
-             parent="fleet.menu_fleet_reporting"/>
+<!--   &lt;!&ndash; Menuitem for Repair Line Summary. &ndash;&gt;-->
+<!--   <menuitem action="action_update_next_service_day"-->
+<!--             name="Update Next Service Day"-->
+<!--             id="next_service_day_menu"-->
+<!--             parent="fleet.menu_fleet_reporting"/>-->
 </odoo>


### PR DESCRIPTION
For issue #60 , hide the menu from Reports-> update next service day.
Its actual usage is from the service, when clicked on done button.
https://prnt.sc/10u095z